### PR TITLE
Remove pip cache in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 
 language: python
-cache: pip
 
 python:
   - '3.6'


### PR DESCRIPTION
See if removing the pip cache prevents the install error on python 2.7