### PR TITLE
Add ability to add additional ansible playbook arg

### DIFF
--- a/sheepdoge/cli.py
+++ b/sheepdoge/cli.py
@@ -43,11 +43,12 @@ def install(config_file):
               type=click.Choice([KennelRunModes.NORMAL,
                                  KennelRunModes.BOOTSTRAP,
                                  KennelRunModes.CRON]))
+@click.option('--ansible-args', type=str)
 @click.option('--config-file', default='kennel.cfg')
-def run(run_mode, config_file):
+def run(run_mode, ansible_args, config_file):
     _initialize_config(config_file)
 
-    kennel = Kennel(run_mode)
+    kennel = Kennel(run_mode, additional_ansible_args=ansible_args)
     run_action = RunAction(kennel)
     Sheepdoge(run_action).run()
 

--- a/sheepdoge/kennel.py
+++ b/sheepdoge/kennel.py
@@ -29,8 +29,9 @@ class Kennel(object):
             shutil.rmtree(kennel_roles_path)
             os.mkdir(kennel_roles_path)
 
-    def __init__(self, kennel_run_mode, config=None):
+    def __init__(self, kennel_run_mode, additional_ansible_args='', config=None):
         self._kennel_run_mode = kennel_run_mode
+        self._additional_ansible_args = additional_ansible_args
         self._config = config or Config.get_config_singleton()
 
     def run(self):
@@ -42,6 +43,9 @@ class Kennel(object):
 
         self._append_vault_password_file_flag_if_file_exists(
             ansible_playbook_cmd)
+
+        if self._additional_ansible_args:
+            ansible_playbook_cmd += self._additional_ansible_args.split(' ')
 
         ShellRunner(ansible_playbook_cmd).run(env_additions={
             'ANSIBLE_ROLES_PATH': self._config.get('kennel_roles_path')

--- a/tests/unit/test_kennel.py
+++ b/tests/unit/test_kennel.py
@@ -128,3 +128,20 @@ class KennelTestCase(unittest.TestCase):
         ansible_playbook_cmd = check_call_args[0]
 
         self.assertFalse('--vault-password-file' in ansible_playbook_cmd)
+
+    @mock.patch('subprocess.check_call')
+    def test_kennel_run_include_additional_ansible_arguments(self, mock_check_call):
+        """Test that we accurately include additonal ansible arguments.
+        """
+        additional_ansible_args = '-K'
+        kennel = Kennel(KennelRunModes.NORMAL,
+                        additional_ansible_args=additional_ansible_args)
+        kennel.run()
+
+        self.assertEqual(mock_check_call.call_count, 1)
+
+        check_call_args, check_call_kwargs = mock_check_call.call_args
+        ansible_playbook_cmd = check_call_args[0]
+
+        self.assertFalse('--vault-password-file' in ansible_playbook_cmd)
+        self.assertEqual(' -K', ansible_playbook_cmd[-3:])


### PR DESCRIPTION
Fix #34 

Sometimes when running `sheepdoge run`, we want to add additional
parameters to `ansible-playbook`. Add a flag to `sheepdoge run` which
provides this ability.